### PR TITLE
add portrait mode adjustments

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -13,7 +13,6 @@
 
 </head>
 <body>
-	<h1>ChickenPaint testbed</h1>
 	<div id="chickenpaint-parent"></div>
     <p></p>
 </body>

--- a/resources/css/chickenpaint.scss
+++ b/resources/css/chickenpaint.scss
@@ -161,7 +161,7 @@
     pen-action:none;
 
     cursor:default;
-    
+
     /* For mobile safari, prevent the canvas being highlighted grey on touch */
     -webkit-tap-highlight-color:transparent;
     -webkit-touch-callout: none;
@@ -213,7 +213,7 @@
     border: 1px solid #ddd;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
-    
+
     display:flex;
     flex-direction:column;
     position:absolute;
@@ -1009,6 +1009,58 @@ body.chickenpaint-full-screen {
     .chickenpaint .checkbox label {
         padding:0;
         padding-left:12px;
+    }
+}
+
+/* Style adjustments for portrait mode */
+@media all and (orientation:portrait) {
+    .chickenpaint-tools {
+        width:70px;
+    }
+
+    .chickenpaint-toolbar-button {
+        margin: 0;
+        padding:0;
+    }
+
+    .chickenpaint-palette-body {
+        max-height: 80vh;
+    }
+
+    .chickenpaint .navbar {
+        min-height: 20px;
+        padding: 0.4rem;
+    }
+
+    .chickenpaint .navbar-nav > li > a {
+        padding-top: 3px;
+        padding-bottom: 3px;
+    }
+
+    .chickenpaint .navbar-brand {
+        padding-top: 3px;
+        padding-bottom: 3px;
+        height: 20px;
+        font-size: 0.9rem;
+    }
+
+    .chickenpaint .navbar-toggler{
+        padding: 0;
+        font-size: 0.9rem;
+    }
+
+    .chickenpaint-palette-body {
+        padding: 0;
+    }
+
+    .chickenpaint-palette-textures .chickenpaint-palette-body {
+        flex-direction: column;
+    }
+
+    .chickenpaint-texture-swatches {
+        flex-basis: unset;
+        flex-shrink: unset;
+        flex-grow: unset;
     }
 }
 


### PR DESCRIPTION
I made a small css adjustment when its running in portrait mode.

Before:
![ksnip_20210514-191225](https://user-images.githubusercontent.com/6495061/118311996-99c26b80-b4e8-11eb-9031-cac00e7206b0.png)
You cant move the brush pattern palette because its handle is out of screen

After:
![image](https://user-images.githubusercontent.com/6495061/118312585-7e0b9500-b4e9-11eb-91ff-1727770b0307.png)

![chickenPaint-portrait-after](https://user-images.githubusercontent.com/6495061/118311976-8f07d680-b4e8-11eb-8e48-42faa9132d79.png)

It is usable on portrait mode screen, also some sizes are dramatically reduced to give more precious space to the canvas, while still being easy to tap


I really wish each of these floating widgets can be collapsible and on portrait modes chickenpaint has most of the widgets collapsed by default.

A very elegant example of UX in a mobile painting app imo is artrage

You can see how its widgets are hidden in the corners by default and they get out of your way while you paint
![ArtRage-for-Android-features1](https://user-images.githubusercontent.com/6495061/118312360-20774880-b4e9-11eb-866d-a35d43b550ab.jpg)

Maybe we can get some more precious canvas space by not wasting it for a branding text and a file button. But I wonder where the file button would go to then? Nexto to where undo/redo is?
![image](https://user-images.githubusercontent.com/6495061/118312760-bf9c4000-b4e9-11eb-81bc-b3f15eef789f.png)


Thats something that would be fantastic to tackle for chickenpaint, as it is probably the best html5 based painting app atm imo and the platform has the huge advantage of working on smartphones out of the box. 
Maybe in the future we can even turn chickenpaint into a progressive web app. It's exposure is terrible atm because the only way to use it is to sign up for an oekaki board, then spend half an hour trying to find the button on it to start chickenpaint.