### PR TITLE
Small screen mode for palettes

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -13,7 +13,6 @@
 
 </head>
 <body>
-	<h1>ChickenPaint testbed</h1>
 	<div id="chickenpaint-parent"></div>
     <p></p>
 </body>

--- a/js/gui/CPMainMenu.js
+++ b/js/gui/CPMainMenu.js
@@ -432,6 +432,7 @@ export default function CPMainMenu(controller, mainGUI) {
                     + '<ul class="navbar-nav mr-auto">'
                     + '</ul>'
                 + '</div>'
+                + '<div class="widget-nav" id="chickenpaint-palette-toggler-content"/>'
             + '</nav>'
         ),
         macPlatform = /^Mac/i.test(navigator.platform);
@@ -612,12 +613,31 @@ export default function CPMainMenu(controller, mainGUI) {
             return topLevelMenuElem;
         }));
     }
-    
+
+    function fillWidgetTray(menuElem, entries) {
+        menuElem.append(entries.filter(item => !!item.mnemonic && controller.isActionSupported(item.action)).map(entry => {
+            let
+                widgetMenuElem = $(
+                    `<button class="widget-toggler" type="button" data-action="${entry.action}" data-checkbox="true" data-selected="${!entry.checked}">`
+                        + '<span>'
+                            + entry.mnemonic
+                        +'</span>'
+                    + '</button>'
+                );
+            widgetMenuElem.click(e => {
+                menuItemClicked(widgetMenuElem);
+                e.preventDefault();
+            })
+            return widgetMenuElem;
+        }));
+    }
+
     this.getElement = function() {
         return bar[0];
     };
     
     fillMenu($(".navbar-nav", bar), MENU_ENTRIES);
+    fillWidgetTray($(".widget-nav", bar), MENU_ENTRIES[5].children);
 
     $(bar).on('click', 'a:not(.dropdown-toggle)', function(e) {
         menuItemClicked($(this));

--- a/js/gui/CPMainMenu.js
+++ b/js/gui/CPMainMenu.js
@@ -618,7 +618,7 @@ export default function CPMainMenu(controller, mainGUI) {
         menuElem.append(entries.filter(item => !!item.mnemonic && controller.isActionSupported(item.action)).map(entry => {
             let
                 widgetMenuElem = $(
-                    `<button class="widget-toggler" type="button" data-action="${entry.action}" data-checkbox="true" data-selected="${!entry.checked}">`
+                    `<button class="widget-toggler selected" type="button" data-action="${entry.action}" data-checkbox="true" data-selected="${!entry.checked}">`
                         + '<span>'
                             + entry.mnemonic
                         +'</span>'

--- a/js/gui/CPPalette.js
+++ b/js/gui/CPPalette.js
@@ -23,6 +23,8 @@
 import $ from "jquery";
 import EventEmitter from "wolfy87-eventemitter";
 
+const windowIsPortraitMode = window.innerHeight > window.innerWidth;
+
 export default function CPPalette(cpController, className, title, resizeVert, resizeHorz) {
     this.title = title;
     this.name = className;
@@ -84,7 +86,13 @@ export default function CPPalette(cpController, className, title, resizeVert, re
         this.setWidth(width);
         this.setHeight(height);
     };
-    
+
+    this.toggleBodyElementVisibility = function() {
+        if (windowIsPortraitMode) {
+            bodyElement.style.display = bodyElement.style.display === "none" ? "block" : "none";
+        }
+    };
+
     function paletteHeaderPointerMove(e) {
         if (e.buttons != 0 && dragAction == "move") {
             that.setLocation(e.pageX - dragOffset.x, e.pageY - dragOffset.y);
@@ -109,6 +117,7 @@ export default function CPPalette(cpController, className, title, resizeVert, re
         if (dragAction == "move") {
             headElement.releasePointerCapture(e.pointerId);
             dragAction = false;
+            that.toggleBodyElementVisibility()
         }
     }
     
@@ -187,12 +196,13 @@ export default function CPPalette(cpController, className, title, resizeVert, re
     titleElem.appendChild(document.createTextNode(this.title));
 
     titleContainer.appendChild(titleElem);
-    titleContainer.appendChild(closeButton);
+    if (!windowIsPortraitMode) titleContainer.appendChild(closeButton);
 
     headElement.appendChild(titleContainer);
 
     bodyElement.className = "chickenpaint-palette-body";
-    
+    bodyElement.style.display = windowIsPortraitMode ? "none" : "block";
+
     containerElement.appendChild(headElement);
     containerElement.appendChild(bodyElement);
 

--- a/js/gui/CPPalette.js
+++ b/js/gui/CPPalette.js
@@ -117,7 +117,7 @@ export default function CPPalette(cpController, className, title, resizeVert, re
         if (dragAction == "move") {
             headElement.releasePointerCapture(e.pointerId);
             dragAction = false;
-            that.toggleBodyElementVisibility()
+            that.toggleBodyElementVisibility();
         }
     }
     

--- a/js/gui/CPPalette.js
+++ b/js/gui/CPPalette.js
@@ -89,7 +89,7 @@ export default function CPPalette(cpController, className, title, resizeVert, re
 
     this.toggleBodyElementVisibility = function() {
         if (windowIsPortraitMode) {
-            bodyElement.style.display = bodyElement.style.display === "none" ? "block" : "none";
+            $(containerElement).toggleClass("collapsed");
         }
     };
 
@@ -201,7 +201,6 @@ export default function CPPalette(cpController, className, title, resizeVert, re
     headElement.appendChild(titleContainer);
 
     bodyElement.className = "chickenpaint-palette-body";
-    bodyElement.style.display = windowIsPortraitMode ? "none" : "block";
 
     containerElement.appendChild(headElement);
     containerElement.appendChild(bodyElement);

--- a/js/gui/CPPalette.js
+++ b/js/gui/CPPalette.js
@@ -23,7 +23,7 @@
 import $ from "jquery";
 import EventEmitter from "wolfy87-eventemitter";
 
-const windowIsPortraitMode = window.innerHeight < 820 || window.innerWidth < 400;
+const isInLowResolutionMode = window.innerHeight < 820 || window.innerWidth < 400;
 
 export default function CPPalette(cpController, className, title, resizeVert, resizeHorz) {
     this.title = title;
@@ -88,7 +88,7 @@ export default function CPPalette(cpController, className, title, resizeVert, re
     };
 
     this.toggleBodyElementVisibility = function() {
-        if (windowIsPortraitMode) {
+        if (isInLowResolutionMode) {
             $(containerElement).toggleClass("collapsed");
         }
     };
@@ -196,7 +196,7 @@ export default function CPPalette(cpController, className, title, resizeVert, re
     titleElem.appendChild(document.createTextNode(this.title));
 
     titleContainer.appendChild(titleElem);
-    if (!windowIsPortraitMode) titleContainer.appendChild(closeButton);
+    if (!isInLowResolutionMode) titleContainer.appendChild(closeButton);
 
     headElement.appendChild(titleContainer);
 

--- a/js/gui/CPPalette.js
+++ b/js/gui/CPPalette.js
@@ -23,7 +23,7 @@
 import $ from "jquery";
 import EventEmitter from "wolfy87-eventemitter";
 
-const windowIsPortraitMode = window.innerHeight > window.innerWidth;
+const windowIsPortraitMode = window.innerHeight < 820 || window.innerWidth < 400;
 
 export default function CPPalette(cpController, className, title, resizeVert, resizeHorz) {
     this.title = title;

--- a/js/gui/CPPaletteManager.js
+++ b/js/gui/CPPaletteManager.js
@@ -169,6 +169,11 @@ export default function CPPaletteManager(cpController) {
         palettes.textures.setLocation(palettes.color.getX() + palettes.color.getWidth() + 4, windowHeight - palettes.textures.getHeight());
 
         palettes.color.setLocation(0, Math.max(palettes.tool.getY() + palettes.tool.getHeight(), windowHeight - palettes.color.getHeight()));
+
+        for (var i in palettes) {
+            var palette = palettes[i];
+            palette.toggleBodyElementVisibility();
+        }
     };
     
     this.getElement = function() {

--- a/js/gui/CPStrokePalette.js
+++ b/js/gui/CPStrokePalette.js
@@ -86,6 +86,7 @@ export default function CPStrokePalette(cpController) {
                 $(this).addClass("selected");
                 
                 cpController.actionPerformed({action: button.command});
+                that.toggleBodyElementVisibility();
             });
 
         body.appendChild(listElem);

--- a/js/gui/CPSwatchesPalette.js
+++ b/js/gui/CPSwatchesPalette.js
@@ -222,6 +222,7 @@ export default function CPSwatchesPalette(controller) {
                 controller.setCurColor(new CPColor(parseInt(swatch.getAttribute("data-color"), 10)));
                 e.stopPropagation();
                 e.preventDefault();
+                that.toggleBodyElementVisibility();
             }
         });
         

--- a/js/gui/CPToolPalette.js
+++ b/js/gui/CPToolPalette.js
@@ -165,6 +165,7 @@ export default function CPToolPalette(cpController) {
                 button = buttons[parseInt(this.getAttribute("data-buttonIndex"), 10)];
 
             cpController.actionPerformed({action: button.command});
+            that.toggleBodyElementVisibility();
         }
     }
 

--- a/resources/css/chickenpaint.scss
+++ b/resources/css/chickenpaint.scss
@@ -750,12 +750,10 @@ body.chickenpaint-full-screen {
 
 .chickenpaint-palette-textures .chickenpaint-palette-body {
     display:flex;
-    flex-direction:row;
+    flex-direction: column;
+    padding: 0;
 }
 .chickenpaint-texture-swatches {
-    flex-basis: 0;
-    flex-shrink: 1;
-    flex-grow: 1;
     line-height:0;
     overflow-y:auto;
 }

--- a/resources/css/chickenpaint.scss
+++ b/resources/css/chickenpaint.scss
@@ -971,6 +971,20 @@ body.chickenpaint-full-screen {
 
 @include chickenpaint-icon-classes;
 
+.chickenpaint .widget-nav {
+    display: none;
+}
+.chickenpaint .widget-nav .widget-toggler {
+    padding: 0.1rem 0.5rem;
+    margin: 0.15rem;
+    font-size: 0.75rem;
+    background-color: transparent;
+    border: 1px solid #00000036;
+    border-radius: 0.25rem;
+}
+.chickenpaint .widget-nav .widget-toggler.selected {
+    background-color: #ffffc4;
+}
 /* More compact styles for small screens */
 @media (max-height: 768px), (max-width: 400px)  {
     .chickenpaint .navbar {
@@ -1018,6 +1032,10 @@ body.chickenpaint-full-screen {
     .chickenpaint .checkbox label {
         padding:0;
         padding-left:12px;
+    }
+
+    .chickenpaint .widget-nav {
+        display: block;
     }
 }
 

--- a/resources/css/chickenpaint.scss
+++ b/resources/css/chickenpaint.scss
@@ -972,20 +972,23 @@ body.chickenpaint-full-screen {
 @include chickenpaint-icon-classes;
 
 /* More compact styles for small screens */
-@media (max-height: 768px) {
+@media (max-height: 768px), (max-width: 400px)  {
     .chickenpaint .navbar {
-        min-height: 40px;
+        min-height: 20px;
+        padding: 0.1rem;
+    }
+
+    .chickenpaint .navbar-toggler {
+        padding: 0;
     }
 
     .chickenpaint .navbar-nav > li > a {
-        padding-top: 10px;
-        padding-bottom: 10px;
+        padding-top: 3px;
+        padding-bottom: 3px;
     }
 
     .chickenpaint .navbar-brand {
-        padding-top: 10px;
-        padding-bottom: 10px;
-        height: 40px;
+        display: none;
     }
 
     .chickenpaint-palette-head {

--- a/resources/css/chickenpaint.scss
+++ b/resources/css/chickenpaint.scss
@@ -750,10 +750,12 @@ body.chickenpaint-full-screen {
 
 .chickenpaint-palette-textures .chickenpaint-palette-body {
     display:flex;
-    flex-direction: column;
-    padding: 0;
+    flex-direction:row;
 }
 .chickenpaint-texture-swatches {
+    flex-basis: 0;
+    flex-shrink: 1;
+    flex-grow: 1;
     line-height:0;
     overflow-y:auto;
 }

--- a/resources/css/chickenpaint.scss
+++ b/resources/css/chickenpaint.scss
@@ -220,6 +220,13 @@
 
     box-shadow: 0 1px 1px rgba(0,0,0,.05);
 }
+.chickenpaint-palette.collapsed {
+    min-height: 27px;
+    max-height: 27px;
+}
+.chickenpaint-palette.collapsed > .chickenpaint-palette-body {
+    display: none;
+}
 .chickenpaint-palette-head {
     background-color:#e8e8e8;
     color:#444;
@@ -476,6 +483,7 @@ body.chickenpaint-full-screen {
 }
 
 .chickenpaint-palette-brush {
+    min-width:200px;
     min-height:250px;
 }
 .chickenpaint-palette-brush .chickenpaint-slider {
@@ -540,7 +548,7 @@ body.chickenpaint-full-screen {
 
 .chickenpaint-palette-layers {
     min-height:250px;
-    min-width:150px;
+    min-width:160px;
 }
 .chickenpaint-palette-layers .chickenpaint-palette-body {
     display:flex;


### PR DESCRIPTION
This PR introduces a new small screen mode for the GUI to make it easier to use on smartphones 

- Chickenpaint works just as before on normal sized screens

When on small screen:
- the palette close button disappears, as it is too easy to tap by mistake and bringing a palette back from the menu is a pain in the neck on a smartphone
- a new behaviour is added to the palette headers. Tapping on it makes it toggle the visibility of its body on/off. This allows us to easily and quickly toggle it when we need it
- On some controls - such as for example when selecting a tool - the palette is smart enough to automatically toggle itself off as it correctly assumes that the user has performed the action (similar to how artrage and other mobile painting apps work). We can do the same for when the user selects another layer, swatch or brush mode. 
- You can still move palettes around by dragging them by the header as before.

![Peek 2021-05-24 20-48](https://user-images.githubusercontent.com/6495061/119400842-9e4e0780-bcd2-11eb-9998-945b5bffdcbe.gif)

I also added palette toggle buttons that will show up in place of that giant Chickenpaint text when on small screens:
![image](https://user-images.githubusercontent.com/6495061/120377937-af6fc780-c315-11eb-959b-ce1eed09040c.png)

they do the same thing the palettes menu in the dropdown does but in a single click instead of three clicks. It would be nice if they get icons of course, for now they are using the mnemonic single letter.


(Tested on a Galaxy note 10 smartphone, does improve the drawing experience a lot as it makes the widgets get out of the way of the canvas as well as making them easier to quickly access and dismiss/close)

closes https://github.com/thenickdude/chickenpaint/issues/32